### PR TITLE
Support for IPython %magics, like %timeit

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,16 @@ rlwrap -H '~/.pdbr_history' pdbr_telnet localhost 6899
 
 ## IPython
 
-Being able to use [ipython](https://ipython.readthedocs.io/), install pdbr with it like below or just install your own version.
+`pdbr` integrates with [IPython](https://ipython.readthedocs.io/).
+
+This makes [`%magics`](https://ipython.readthedocs.io/en/stable/interactive/magics.html) available, for example:
+
+```python
+(Pdbr) %timeit range(100)
+104 ns ± 2.05 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
+```
+
+To enable `IPython` features, install it separately, or like below:
 
 ```
 pip install pdbr[ipython]

--- a/noxfile.py
+++ b/noxfile.py
@@ -22,15 +22,24 @@ def check(session, reuse_venv=True):
 @nox.session(python=["3.7", "3.8", "3.9", "3.10"])
 def test(session, reuse_venv=True):
     session.install(
+        ".",
         "pytest",
         "pytest-cov",
         "rich",
         "icecream",
         "prompt_toolkit",
         "sqlparse",
-        "IPython",
+        "IPython==7.32.0",
     )
-    session.run("pytest", "--cov-report", "term-missing", "--cov=pdbr", "tests")
+    session.run(
+        "pytest",
+        "--cov-report",
+        "term-missing",
+        "--cov=pdbr",
+        "--capture=no",
+        "--disable-warnings",
+        "tests",
+    )
 
 
 @nox.session

--- a/noxfile.py
+++ b/noxfile.py
@@ -22,7 +22,13 @@ def check(session, reuse_venv=True):
 @nox.session(python=["3.7", "3.8", "3.9", "3.10"])
 def test(session, reuse_venv=True):
     session.install(
-        "pytest", "pytest-cov", "rich", "icecream", "prompt_toolkit", "sqlparse"
+        "pytest",
+        "pytest-cov",
+        "rich",
+        "icecream",
+        "prompt_toolkit",
+        "sqlparse",
+        "IPython",
     )
     session.run("pytest", "--cov-report", "term-missing", "--cov=pdbr", "tests")
 

--- a/pdbr/_pdbr.py
+++ b/pdbr/_pdbr.py
@@ -367,9 +367,7 @@ def rich_pdb_klass(base, is_celery=False, context=None, show_layouts=True):
             elif line.endswith("?"):
                 line = "pinfo " + line[:-1]
 
-            line = super().precmd(line)
-
-            return line
+            return super().precmd(line)
 
         def onecmd(self, line: str) -> bool:
             """

--- a/pdbr/_pdbr.py
+++ b/pdbr/_pdbr.py
@@ -382,7 +382,8 @@ def rich_pdb_klass(base, is_celery=False, context=None, show_layouts=True):
                 if line.startswith("%"):
                     if line.startswith("%%"):
                         self.error(
-                            f'Cell magics (multiline) are not yet supported. Use a single "%" instead.'
+                            "Cell magics (multiline) are not yet supported. "
+                            "Use a single '%' instead."
                         )
                         return ""
                     return self.run_magic(line[1:])

--- a/pdbr/_pdbr.py
+++ b/pdbr/_pdbr.py
@@ -361,15 +361,6 @@ def rich_pdb_klass(base, is_celery=False, context=None, show_layouts=True):
         def message(self, msg):
             self._print(msg)
 
-        def onecmd(self, line: str) -> bool:
-            if not isinstance(line, str):
-                self._print(line, style="rgb(255,255,255)")
-                return False
-            try:
-                return super().onecmd(line)
-            except Exception as e:
-                self.error(f"{type(e).__qualname__} in onecmd({line!r}): {e}")
-                return True
 
         def precmd(self, line) -> str:
             """

--- a/pdbr/_pdbr.py
+++ b/pdbr/_pdbr.py
@@ -361,6 +361,16 @@ def rich_pdb_klass(base, is_celery=False, context=None, show_layouts=True):
         def message(self, msg):
             self._print(msg)
 
+        def precmd(self, line):
+            if line.endswith("??"):
+                line = "pinfo2 " + line[:-2]
+            elif line.endswith("?"):
+                line = "pinfo " + line[:-1]
+
+            line = super().precmd(line)
+
+            return line
+
         def onecmd(self, line: str) -> bool:
             """
             Invokes 'run_magic()' if the line starts with a '%'.
@@ -441,12 +451,10 @@ def rich_pdb_klass(base, is_celery=False, context=None, show_layouts=True):
                 # This is indeed the case with do_pdef, do_pdoc etc,
                 # which are defined by our base class (IPython.core.debugger.Pdb).
                 result = getattr(self, f"do_{magic_name}")(arg)
-                # TODO: test for zombie lastcmd in this case
             else:
                 magic_fn = self.shell.find_line_magic(magic_name)
                 if not magic_fn:
                     self.error(f"Line Magic %{magic_name} not found")
-                    # TODO: test for zombie lastcmd in this case
                     return ""
                 if magic_name in ("time", "timeit"):
                     result = magic_fn(

--- a/pdbr/_pdbr.py
+++ b/pdbr/_pdbr.py
@@ -361,6 +361,25 @@ def rich_pdb_klass(base, is_celery=False, context=None, show_layouts=True):
         def message(self, msg):
             self._print(msg)
 
+        def precmd(self, line) -> str:
+            """
+            Invokes 'run_magic()' if the line starts with a '%'.
+            The return value is passed on to 'onecmd()' method by 'cmdloop()'.
+            """
+            orig_line = line
+            try:
+                line = line.strip()
+                if line.startswith("%"):
+                    if line.startswith("%%"):
+                        self.error(f'Cell magics (multiline) are not yet supported. Use a single "%" instead.')
+                        return ""
+                    return self.run_magic(line[1:])
+                return super().precmd(line)
+
+            except Exception as e:
+                self.error(f'{type(e).__qualname__} in precmd({line!r}): {e}')
+                return orig_line
+
         def _print(
             self, val, prefix=None, style=None, print_layout=True, dont_escape=False
         ):

--- a/pdbr/_pdbr.py
+++ b/pdbr/_pdbr.py
@@ -361,7 +361,6 @@ def rich_pdb_klass(base, is_celery=False, context=None, show_layouts=True):
         def message(self, msg):
             self._print(msg)
 
-
         def precmd(self, line) -> str:
             """
             Invokes 'run_magic()' if the line starts with a '%'.

--- a/pdbr/_pdbr.py
+++ b/pdbr/_pdbr.py
@@ -440,18 +440,24 @@ def rich_pdb_klass(base, is_celery=False, context=None, show_layouts=True):
                 # We want to use do_{magic_name} methods if defined.
                 # This is indeed the case with do_pdef, do_pdoc etc,
                 # which are defined by our base class (IPython.core.debugger.Pdb).
-                result = getattr(self, f"do_{magic_name}")(line)
-                return result or ""
-            magic_fn = self.shell.find_line_magic(magic_name)
-            if not magic_fn:
-                self.error(f"Line Magic %{magic_name} not found")
-                return ""
-            if magic_name in ("time", "timeit"):
-                result = magic_fn(
-                    arg, local_ns={**self.curframe_locals, **self.curframe.f_globals}
-                )
+                result = getattr(self, f"do_{magic_name}")(arg)
+                # TODO: test for zombie lastcmd in this case
             else:
-                result = magic_fn(arg)
-            return result or ""
+                magic_fn = self.shell.find_line_magic(magic_name)
+                if not magic_fn:
+                    self.error(f"Line Magic %{magic_name} not found")
+                    # TODO: test for zombie lastcmd in this case
+                    return ""
+                if magic_name in ("time", "timeit"):
+                    result = magic_fn(
+                        arg,
+                        local_ns={**self.curframe_locals, **self.curframe.f_globals},
+                    )
+                else:
+                    result = magic_fn(arg)
+            if result:
+                result = str(result)
+                self._print(result)
+            return ""
 
     return RichPdb

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,10 @@ max-line-length = 88
 [tool:isort]
 profile = black
 
+
+[tool:pytest]
+addopts = --capture=no --disable-warnings
+
 [pdbr]
 use_traceback= True
 style=dim

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+"""
+Add '--skip-slow' cmdline option to skip tests that are marked with @pytest.mark.slow.
+"""
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--skip-slow", action="store_true", default=False, help="Skip slow tests"
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if not config.getoption("--skip-slow"):
+        return
+    skip_slow = pytest.mark.skip(reason="Specified --skip-slow")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -152,6 +152,7 @@ def test_no_zombie_lastcmd(capsys, RichIPdb):
     assert captured.out.endswith(Path.cwd().absolute().as_posix() + "\n")
     assert "SHOULD_NOT_BE_IN_%pwd_OUTPUT" not in captured.out
 
+
 def test_TerminalPdb_magics_override(tmp_path, capsys, RichIPdb):
     from IPython.utils.text import dedent
 
@@ -222,7 +223,7 @@ def test_TerminalPdb_magics_override(tmp_path, capsys, RichIPdb):
         % tmp_file_content
     )
     assert untagged == expected_pinfo2, untagged
-    
+
     # rpdb.onecmd("%psource foo")
     # rpdb.onecmd("foo?")
     # rpdb.onecmd("foo??")

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -26,6 +26,7 @@ def untag(s):
     s = s.replace("\x1b[?2004l", "")
     return TAG_RE.sub("", s)
 
+
 def unquote(s):
     """
     >>> unquote('"foo"')
@@ -37,7 +38,8 @@ def unquote(s):
         if s.startswith(quote) and s.endswith(quote):
             return s[1:-1]
     return s
-    
+
+
 TMP_FILE_CONTENT = '''def foo(arg):
     """Foo docstring"""
     pass
@@ -274,6 +276,7 @@ def test_expr_questionmark_pinfo(tmp_path, capsys, RichIPdb):
     magic_pinfo2_foo_output = capsys.readouterr().out
     assert magic_pinfo2_foo_output == magic_foo_qmark2_output
 
+
 def test_filesystem_magics(capsys, RichIPdb):
     cwd = Path.cwd().absolute().as_posix()
     rpdb = RichIPdb(stdout=sys.stdout)
@@ -283,7 +286,7 @@ def test_filesystem_magics(capsys, RichIPdb):
     rpdb.onecmd("import os; os.getcwd()")
     pwd_output = unquote(capsys.readouterr().out.strip())
     assert pwd_output == cwd
-    
+
     new_dir = str(Path.cwd().absolute().parent)
     rpdb.onecmd(f"%cd {new_dir}")
     cd_output = untag(capsys.readouterr().out.strip())

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -252,12 +252,14 @@ def test_expr_questionmark_pinfo(tmp_path, capsys, RichIPdb):
     rpdb.onecmd(rpdb.precmd("foo?"))
     magic_foo_qmark_output = capsys.readouterr().out
     untagged = untag(magic_foo_qmark_output).strip()
-    expected_pinfo = re.compile(dedent(
-        f"""Signature: foo\(arg\)
+    expected_pinfo = re.compile(
+        dedent(
+            f"""Signature: foo\(arg\)
     Docstring: Bar docstring
     File:      /tmp/.*/foo.py
     Type:      function"""
-            ))
+        )
+    )
     assert expected_pinfo.fullmatch(untagged), untagged
 
     # pinfo2

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -252,13 +252,13 @@ def test_expr_questionmark_pinfo(tmp_path, capsys, RichIPdb):
     rpdb.onecmd(rpdb.precmd("foo?"))
     magic_foo_qmark_output = capsys.readouterr().out
     untagged = untag(magic_foo_qmark_output).strip()
-    expected_pinfo = dedent(
-        f"""Signature: foo(arg)
+    expected_pinfo = re.compile(dedent(
+        f"""Signature: foo\(arg\)
     Docstring: Bar docstring
-    File:      {tmp_file.absolute()}
+    File:      /tmp/.*/foo.py
     Type:      function"""
-            )
-    assert untagged.endswith(expected_pinfo), untagged
+            ))
+    assert expected_pinfo.fullmatch(untagged), untagged
 
     # pinfo2
     rpdb.onecmd(rpdb.precmd("foo??"))

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -212,17 +212,17 @@ def test_TerminalPdb_magics_override(tmp_path, capsys, RichIPdb):
     rpdb.onecmd("%pinfo2 foo")
     magic_pinfo2_foo_output = capsys.readouterr().out
     untagged = untag(magic_pinfo2_foo_output).strip()
-    expected_pinfo2 = (
+    expected_pinfo2 = re.compile(
         dedent(
-            f"""Signature: foo(arg)
-    Source:
+            rf"""Signature: foo\(arg\)
+    Source:\s*
     %s
     File:      {tmp_file.absolute()}
     Type:      function"""
         )
-        % tmp_file_content
+        % re.escape(tmp_file_content)
     )
-    assert untagged == expected_pinfo2, untagged
+    assert expected_pinfo2.fullmatch(untagged), untagged
 
     # rpdb.onecmd("%psource foo")
     # rpdb.onecmd("foo?")

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -74,8 +74,8 @@ def pdbr_child_process(tmp_path) -> spawn:
     )
     child.expect("foo.py")
     child.expect("breakpoint")
-    child.sendeof()
-    child.timeout = 3
+    # child.sendeof()
+    child.timeout = 10
     return child
 
 
@@ -115,7 +115,7 @@ class TestPdbrChildProcess:
     def test_time(self, pdbr_child_process):
         pdbr_child_process.sendline("from time import sleep")
         pdbr_child_process.sendline("%time sleep(0.1)")
-        pdbr_child_process.expect("CPU time")
+        pdbr_child_process.expect(re.compile("CPU times: .+"))
         pdbr_child_process.expect("Wall time: 100 ms")
 
     def test_timeit(self, pdbr_child_process):
@@ -265,13 +265,13 @@ def test_expr_questionmark_pinfo(tmp_path, capsys, RichIPdb):
     untagged = untag(magic_foo_qmark_output).strip()
     expected_pinfo = re.compile(
         dedent(
-            rf"""Signature: foo\(arg\)
+            rf""".*Signature: foo\(arg\)
     Docstring: Foo docstring
     File:      /tmp/.*/{tmp_file.name}
     Type:      function"""
         )
     )
-    assert expected_pinfo.fullmatch(untagged), untagged
+    assert expected_pinfo.fullmatch(untagged), f"untagged = {untagged!r}"
 
     # pinfo2
     rpdb.onecmd(rpdb.precmd("foo??"))

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1,9 +1,17 @@
+import inspect
 import os
+import re
 import sys
 
 import pexpect
 import pytest
 from pexpect import spawn
+from rich.console import Console
+from rich.theme import Theme
+
+from pdbr._pdbr import rich_pdb_klass
+
+NUMBER_RE = "[\d.e+_,-]+"  # Matches 1e+03, 1.0e-03, 1_000, 1,000
 
 
 @pytest.fixture
@@ -17,13 +25,75 @@ def pdbr_child_process(tmp_path) -> spawn:
     return child
 
 
-def test_time(pdbr_child_process):
-    pdbr_child_process.sendline("from time import sleep")
-    pdbr_child_process.sendline("%time sleep(0.1)")
-    pdbr_child_process.expect("CPU time")
-    pdbr_child_process.expect("Wall time: 100 ms")
+@pytest.fixture
+def RichIPdb():
+    """
+    In contrast to the normal RichPdb in test_pdbr.py which inherits from
+    built-in pdb.Pdb, this one inherits from IPython's TerminalPdb, which holds
+    a 'shell' attribute that is a IPython TerminalInteractiveShell.
+    This is required for the magic commands to work (and happens automatically
+    when the user runs pdbr when IPython is importable).
+    """
+    from IPython.terminal.debugger import TerminalPdb
+
+    currentframe = inspect.currentframe()
+
+    def rich_ipdb_klass(*args, **kwargs):
+        ripdb = rich_pdb_klass(TerminalPdb, show_layouts=False)(*args, **kwargs)
+        # Set frame and stack related self-attributes
+        ripdb.botframe = currentframe.f_back
+        ripdb.setup(currentframe.f_back, None)
+        # Set the console's file to stdout so that we can capture the output
+        _console = Console(
+            file=sys.stdout,
+            theme=Theme(
+                {"info": "dim cyan", "warning": "magenta", "danger": "bold red"}
+            ),
+        )
+        ripdb._console = _console
+        return ripdb
+
+    return rich_ipdb_klass
 
 
-def test_timeit(pdbr_child_process):
-    pdbr_child_process.sendline("%timeit -n 1 -r 1 pass")
-    pdbr_child_process.expect_exact("std. dev. of 1 run, 1 loop each)")
+@pytest.mark.slow
+class TestPdbrChildProcess:
+    def test_time(self, pdbr_child_process):
+        pdbr_child_process.sendline("from time import sleep")
+        pdbr_child_process.sendline("%time sleep(0.1)")
+        pdbr_child_process.expect("CPU time")
+        pdbr_child_process.expect("Wall time: 100 ms")
+
+    def test_timeit(self, pdbr_child_process):
+        pdbr_child_process.sendline("%timeit -n 1 -r 1 pass")
+        pdbr_child_process.expect_exact("std. dev. of 1 run, 1 loop each)")
+
+
+def test_precmd_time_line_magic(capsys, RichIPdb):
+    RichIPdb().precmd("%time pass")
+    captured = capsys.readouterr()
+    output = captured.out
+    assert re.search(
+        rf"CPU times: user {NUMBER_RE} [mµn]s, sys: {NUMBER_RE} [mµn]s, total: {NUMBER_RE} [mµn]s\n"
+        rf"Wall time: {NUMBER_RE} [mµn]s",
+        output,
+    )
+
+
+def test_precmd_unsupported_cell_magic(capsys, RichIPdb):
+    RichIPdb().precmd("%%time pass")
+    captured = capsys.readouterr()
+    output = captured.out
+    assert (
+        output
+        == f"*** Cell magics (multiline) are not yet supported. Use a single '%' instead.\n"
+    )
+    cmd = "%%ls"
+    line = RichIPdb().precmd(cmd)
+    captured_output = capsys.readouterr().out
+    assert line == ""
+    RichIPdb().error(
+        "Cell magics (multiline) are not yet supported. Use a single '%' instead."
+    )
+    cell_magics_error = capsys.readouterr().out
+    assert cell_magics_error == captured_output

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -1,0 +1,29 @@
+import os
+import sys
+
+import pexpect
+import pytest
+from pexpect import spawn
+
+
+@pytest.fixture
+def pdbr_child_process(tmp_path) -> spawn:
+    file = tmp_path / "foo.py"
+    file.write_text("breakpoint()")
+    env = os.environ.copy()
+    env["IPY_TEST_SIMPLE_PROMPT"] = "1"
+    child = pexpect.spawn(sys.executable, ["-m", "pdbr", str(file)], env=env)
+    child.timeout = 3
+    return child
+
+
+def test_time(pdbr_child_process):
+    pdbr_child_process.sendline("from time import sleep")
+    pdbr_child_process.sendline("%time sleep(0.1)")
+    pdbr_child_process.expect("CPU time")
+    pdbr_child_process.expect("Wall time: 100 ms")
+
+
+def test_timeit(pdbr_child_process):
+    pdbr_child_process.sendline("%timeit -n 1 -r 1 pass")
+    pdbr_child_process.expect_exact("std. dev. of 1 run, 1 loop each)")

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -12,14 +12,15 @@ from rich.theme import Theme
 
 from pdbr._pdbr import rich_pdb_klass
 
-NUMBER_RE = "[\d.e+_,-]+"  # Matches 1e+03, 1.0e-03, 1_000, 1,000
+NUMBER_RE = r"[\d.e+_,-]+"  # Matches 1e+03, 1.0e-03, 1_000, 1,000
 
 TAG_RE = re.compile(r"\x1b[\[\]]+[\dDClhJt;?]+m?")
 
 
 def untag(s):
     """Not perfect, but does the job.
-    >>> untag('\x1b[0mfoo\x1b[0m\x1b[0;34m(\x1b[0m\x1b[0marg\x1b[0m\x1b[0;34m)\x1b[0m\x1b[0;34m\x1b[0m\x1b[0;34m\x1b[0m\x1b[0m')
+    >>> untag('\x1b[0mfoo\x1b[0m\x1b[0;34m(\x1b[0m\x1b[0marg\x1b[0m\x1b[0;34m)\x1b[0m'
+    >>>       '\x1b[0;34m\x1b[0m\x1b[0;34m\x1b[0m\x1b[0m')
     'foo(arg)'
     """
     s = s.replace("\x07", "")
@@ -47,7 +48,7 @@ TMP_FILE_CONTENT = '''def foo(arg):
 
 
 def import_tmp_file(rpdb, tmp_path: Path, file_content=TMP_FILE_CONTENT) -> Path:
-    """Creates a temporary file, writes `file_content` to it and makes pdbr import it."""
+    """Creates a temporary file, writes `file_content` to it and makes pdbr import it"""
     tmp_file = tmp_path / "foo.py"
     tmp_file.write_text(file_content)
 
@@ -127,8 +128,10 @@ def test_onecmd_time_line_magic(capsys, RichIPdb):
     captured = capsys.readouterr()
     output = captured.out
     assert re.search(
-        rf"CPU times: user {NUMBER_RE} [mµn]s, sys: {NUMBER_RE} [mµn]s, total: {NUMBER_RE} [mµn]s\n"
-        rf"Wall time: {NUMBER_RE} [mµn]s",
+        f"CPU times: user {NUMBER_RE} [mµn]s, "
+        f"sys: {NUMBER_RE} [mµn]s, "
+        f"total: {NUMBER_RE} [mµn]s\n"
+        f"Wall time: {NUMBER_RE} [mµn]s",
         output,
     )
 
@@ -137,7 +140,7 @@ def test_onecmd_unsupported_cell_magic(capsys, RichIPdb):
     RichIPdb().onecmd("%%time pass")
     captured = capsys.readouterr()
     output = captured.out
-    error = f"Cell magics (multiline) are not yet supported. Use a single '%' instead."
+    error = "Cell magics (multiline) are not yet supported. Use a single '%' instead."
     assert output == "*** " + error + "\n"
     cmd = "%%time"
     stop = RichIPdb().onecmd(cmd)
@@ -175,8 +178,9 @@ def test_no_zombie_lastcmd(capsys, RichIPdb):
 
 def test_IPython_Pdb_magics_implementation(tmp_path, capsys, RichIPdb):
     """
-    We test do_{magic} methods that are concretely implemented by IPython.core.debugger.Pdb,
-    and don't default to IPython's 'InteractiveShell.run_line_magic()' like the other magics.
+    We test do_{magic} methods that are concretely implemented by
+    IPython.core.debugger.Pdb, and don't default to IPython's
+    'InteractiveShell.run_line_magic()' like the other magics.
     """
     from IPython.utils.text import dedent
 
@@ -261,7 +265,7 @@ def test_expr_questionmark_pinfo(tmp_path, capsys, RichIPdb):
     untagged = untag(magic_foo_qmark_output).strip()
     expected_pinfo = re.compile(
         dedent(
-            f"""Signature: foo\(arg\)
+            rf"""Signature: foo\(arg\)
     Docstring: Foo docstring
     File:      /tmp/.*/{tmp_file.name}
     Type:      function"""

--- a/tests/test_pdbr.py
+++ b/tests/test_pdbr.py
@@ -40,3 +40,20 @@ def test_print_without_escape_tag(capsys, RichPdb):
     RichPdb()._print("msg[tag]", dont_escape=True)
     captured = capsys.readouterr()
     assert captured.out == "msg\n"
+
+def test_precmd(capsys, RichPdb):
+    rpdb = RichPdb()
+    cmd = 'print("msg")'
+    line = rpdb.precmd(cmd)
+    captured = capsys.readouterr()
+    assert line == cmd
+    assert captured.out == ""
+    
+    # Cell magics aren't supported, assert that it's not executed
+    cmd = '%%ls'
+    line = rpdb.precmd(cmd)
+    captured_output = capsys.readouterr().out
+    assert line == ""
+    rpdb.error('Cell magics (multiline) are not yet supported. Use a single "%" instead.')
+    cell_magics_error = capsys.readouterr().out
+    assert cell_magics_error == captured_output

--- a/tests/test_pdbr.py
+++ b/tests/test_pdbr.py
@@ -50,13 +50,3 @@ def test_precmd(capsys, RichPdb):
     assert line == cmd
     assert captured.out == ""
 
-    # Cell magics aren't supported, assert that it's not executed
-    cmd = "%%ls"
-    line = rpdb.precmd(cmd)
-    captured_output = capsys.readouterr().out
-    assert line == ""
-    rpdb.error(
-        "Cell magics (multiline) are not yet supported. Use a single '%' instead."
-    )
-    cell_magics_error = capsys.readouterr().out
-    assert cell_magics_error == captured_output

--- a/tests/test_pdbr.py
+++ b/tests/test_pdbr.py
@@ -41,6 +41,7 @@ def test_print_without_escape_tag(capsys, RichPdb):
     captured = capsys.readouterr()
     assert captured.out == "msg\n"
 
+
 def test_precmd(capsys, RichPdb):
     rpdb = RichPdb()
     cmd = 'print("msg")'
@@ -48,12 +49,14 @@ def test_precmd(capsys, RichPdb):
     captured = capsys.readouterr()
     assert line == cmd
     assert captured.out == ""
-    
+
     # Cell magics aren't supported, assert that it's not executed
-    cmd = '%%ls'
+    cmd = "%%ls"
     line = rpdb.precmd(cmd)
     captured_output = capsys.readouterr().out
     assert line == ""
-    rpdb.error('Cell magics (multiline) are not yet supported. Use a single "%" instead.')
+    rpdb.error(
+        'Cell magics (multiline) are not yet supported. Use a single "%" instead.'
+    )
     cell_magics_error = capsys.readouterr().out
     assert cell_magics_error == captured_output

--- a/tests/test_pdbr.py
+++ b/tests/test_pdbr.py
@@ -49,4 +49,3 @@ def test_precmd(capsys, RichPdb):
     captured = capsys.readouterr()
     assert line == cmd
     assert captured.out == ""
-

--- a/tests/test_pdbr.py
+++ b/tests/test_pdbr.py
@@ -56,7 +56,7 @@ def test_precmd(capsys, RichPdb):
     captured_output = capsys.readouterr().out
     assert line == ""
     rpdb.error(
-        'Cell magics (multiline) are not yet supported. Use a single "%" instead.'
+        "Cell magics (multiline) are not yet supported. Use a single '%' instead."
     )
     cell_magics_error = capsys.readouterr().out
     assert cell_magics_error == captured_output


### PR DESCRIPTION
Hi, thanks for pdbr!

Since IPython is already baked into RichPdb (if available), it itched me to unlock some IPython features, so I started with `%magic` commands.
This is something that I've wanted to do for some time now; pdbr stands for a lot of things I enjoy: terminal debuggers, `IPython` and `rich` library.

I've added 2 functions in `_pdbr.py`, wrote a test in `test_pdbr.py`, and added a description of the feature in the `README.md`. 

I had trouble testing the actual magic functionality, because when trying to init a `rich_pdb_klass(IPython.terminal.debugger.TerminalPdb)` inside a test, it raises an exception, complaining about stdout not being a terminal. I couldn't get past that.

Additionally, some magics don't work out of the box, for example `%lsmagic`. This can be fixed by overriding `onecmd()`, but I wanted to know if you're at all interested in this PR's idea before adding more changes. Let me know if you want this fixed as well :)

Thanks,
Gilad