### PR TITLE
Add support for Python 3.11+

### DIFF
--- a/pdbr/_pdbr.py
+++ b/pdbr/_pdbr.py
@@ -1,7 +1,6 @@
 import inspect
 import io
 import re
-
 from pathlib import Path
 from pdb import Pdb
 

--- a/pdbr/_pdbr.py
+++ b/pdbr/_pdbr.py
@@ -1,13 +1,9 @@
 import inspect
 import io
 import re
+from inspect import getsourcelines
 from pathlib import Path
 from pdb import Pdb
-
-try:
-    from inspect import getsourcelines  # Python 3.11+
-except ImportError:
-    from pdb import getsourcelines
 
 import sqlparse
 from rich import box, markup

--- a/pdbr/_pdbr.py
+++ b/pdbr/_pdbr.py
@@ -1,8 +1,14 @@
 import inspect
 import io
 import re
+
 from pathlib import Path
-from pdb import Pdb, getsourcelines
+from pdb import Pdb
+
+try:
+    from inspect import getsourcelines  # Python 3.11+
+except ImportError:
+    from pdb import getsourcelines
 
 import sqlparse
 from rich import box, markup


### PR DESCRIPTION
In Python 3.11 the `getsourcelines` function has been removed from `pdb`, however, it is available from `inspect`.

There are multiple approaches to work around this, I have solved it with a `try except` clause I don't know if that's the preferred way ;)